### PR TITLE
Changed FAQ list

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -103,11 +103,10 @@
 <div class="container moduleZero">
   <div class="row">
       <div id="list-example" class="list-group col-md-3">
-          <a class="list-group-item list-group-item-action" href="#list-item-1">Item 1</a>
-          <a class="list-group-item list-group-item-action" href="#list-item-2">Item 2</a>
-          <a class="list-group-item list-group-item-action" href="#list-item-3">Item 3</a>
-          <a class="list-group-item list-group-item-action" href="#list-item-4">Item 4</a>
-          <a class="list-group-item list-group-item-action" href="#list-item-5">Item 5</a>
+          <a class="list-group-item list-group-item-action" href="#list-item-1">I'm not a developer / I don't know how to code / I don’t think I know enough to participate.</a>
+          <a class="list-group-item list-group-item-action" href="#list-item-2">What will class be like?</a>
+          <a class="list-group-item list-group-item-action" href="#list-item-3">What happens to the projects following the hackathon? How often do workgroups stay together and further develop a project?</a>
+          <a class="list-group-item list-group-item-action" href="#list-item-4">What kind of job can I expect?</a>
         </div>
         <div data-spy="scroll" data-target="#list-example" data-offset="0" class="faqScroll col-md-9">
           <h4 class="moduleTitle" id="list-item-1">I'm not a developer / I don't know how to code / I don’t think I know enough to participate.</h4>

--- a/faq.html
+++ b/faq.html
@@ -110,25 +110,23 @@
           <a class="list-group-item list-group-item-action" href="#list-item-5">Item 5</a>
         </div>
         <div data-spy="scroll" data-target="#list-example" data-offset="0" class="faqScroll col-md-9">
-          <h4 class="moduleTitle" id="list-item-1">Item 1</h4>
-          <p>Not a problem! It is entirely irrelevant what your experience is going into a hackathon, it is more about your interest
-              in technology. There will be a way for you to make an impact, we're certain of it. We make our hackathons very
-              welcoming and beginner-friendly through mentors at the event and our amazing community that is happy to help new
-              folks. If you want to dive into code or sharpen your skills, check out Treehouse, Codecademy, or FreeCodeCamp.</p>
-          <h4 class="moduleTitle" id="list-item-2">Item 2</h4>
+          <h4 class="moduleTitle" id="list-item-1">I'm not a developer / I don't know how to code / I don’t think I know enough to participate.</h4>
+          <p>Not a problem! It is entirely irrelevant what your experience is going into the course; it is more about your interest
+              in technology. There will be a way for you to make an impact, we're certain of it. We make our lessons very
+              welcoming and beginner-friendly via mentoring throughout the course and our amazing community that is happy to help new
+              folks.</p>
+          <h4 class="moduleTitle" id="list-item-2">What will class be like?</h4>
           <p>Class is every weekday from 9AM - 5PM, with holiday and vacation breaks. We assign daily homework and projects,
               including over holidays; anticipate 10-15 hours of study outside of the class per week. We also ask that you participate
               in community events to exemplify our values of community, inclusivity, and lifelong learning.</p>
-          <h4 class="moduleTitle" id="list-item-3">Item 3</h4>
-          <p>Projects will be on Devpost, and we will post winners to our website. If teams have loose ends to tie up they might
+          <h4 class="moduleTitle" id="list-item-3">What happens to the projects following the hackathon? How often do workgroups stay together and further develop a project?</h4>
+          <p>Projects will be on Devpost, and we will post details of completed projects to our website in order to generate interest in our graduates and our course. If groups have loose ends to tie up they might
               meet to finish the project - it really depends on their availability. We encourage teams to keep on hacking even
-              after the event is over!</p>
-          <h4 class="moduleTitle" id="list-item-4">Item 4</h4>
+              after the students graduate!</p>
+          <h4 class="moduleTitle" id="list-item-4">What kind of job can I expect?</h4>
           <p>We’ll train you on how to learn and how to be a full-stack developer, but very likely you’ll find a particular
               part of software development that suits you. There are lots of options and our graduates have gone on to work in
               many different areas of software development</p>
-        <h4 class="moduleTitle" id="list-item-5">Item 5</h4>
-        <p>We’ll train you on how to learn and how to be a full-stack developer, but very likely you’ll find a particular part of software development that suits you. There are lots of options and our graduates have gone on to work in many different areas of software development</p>
         </div>
   </div>
   <div class="row marginTopBottom text-center">


### PR DESCRIPTION
Added question headings to answers, after googling the origin of the answer text.
Changed references to 'hackathon', 'event', 'teams' to reflect 'course', 'lessons', 'workgroups', 'students', etc.
Removed 'Item 5' as it was a verbatim copy of 'Item 4'